### PR TITLE
Improve pagination of Discord results

### DIFF
--- a/src/discordParser.ts
+++ b/src/discordParser.ts
@@ -113,31 +113,39 @@ const parserRules: ParserRules = {
 		match: inlineRegex(/^(https?:\/\/[^\s<]+[^<.,:;"')\]\s])/),
 		parse: (capture: Capture) => {
 			let url = capture[1]
-			const parsedUrl = new URL(url)
-			if (parsedUrl.hostname === 'toddle.dev') {
-				const pathParts = parsedUrl.pathname
-					.split('/')
-					.slice(1)
-					.filter((p) => p !== '')
-				if (pathParts[0] === 'docs') {
-					// Handle docs redirects
-					url =
-						DOCS_REDIRECTS[parsedUrl.pathname.slice(1)] ??
-						'https://docs.nordcraft.com'
-				} else if (pathParts[0] === 'projects') {
-					if (pathParts.length > 2) {
-						url = `https://editor.nordcraft.com${parsedUrl.pathname}${parsedUrl.search}`
+			try {
+				const parsedUrl = new URL(url)
+				if (parsedUrl.hostname === 'toddle.dev') {
+					const pathParts = parsedUrl.pathname
+						.split('/')
+						.slice(1)
+						.filter((p) => p !== '')
+					if (pathParts[0] === 'docs') {
+						// Handle docs redirects
+						url =
+							DOCS_REDIRECTS[parsedUrl.pathname.slice(1)] ??
+							'https://docs.nordcraft.com'
+					} else if (pathParts[0] === 'projects') {
+						if (pathParts.length > 2) {
+							url = `https://editor.nordcraft.com${parsedUrl.pathname}${parsedUrl.search}`
+						} else {
+							url = `https://app.nordcraft.com${parsedUrl.pathname}${parsedUrl.search}`
+						}
+					} else if (pathParts[0] === 'blog') {
+						// Handle blog redirects
+						url = `https://blog.nordcraft.com/${pathParts[1] ?? ''}`
+					} else if (pathParts[0] === 'pricing') {
+						url = 'https://nordcraft.com/pricing'
 					} else {
-						url = `https://app.nordcraft.com${parsedUrl.pathname}${parsedUrl.search}`
+						url = `https://nordcraft.com${parsedUrl.pathname}${parsedUrl.search}`
 					}
-				} else if (pathParts[0] === 'blog') {
-					// Handle blog redirects
-					url = `https://blog.nordcraft.com/${pathParts[1] ?? ''}`
-				} else if (pathParts[0] === 'pricing') {
-					url = 'https://nordcraft.com/pricing'
-				} else {
-					url = `https://nordcraft.com${parsedUrl.pathname}${parsedUrl.search}`
 				}
+			} catch (error) {
+				// eslint-disable-next-line no-console
+				console.error(
+					`Error parsing URL: ${error instanceof Error ? error.message : 'Unknown error'}`,
+					url,
+				)
 			}
 			return {
 				content: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ export default {
 	// The scheduled handler is invoked at the interval set in our wrangler.toml's
 	// [[triggers]] configuration.
 	async scheduled(_event, env): Promise<void> {
+		const start = performance.now()
 		const {
+			allMessageIds,
 			newChannels,
 			newTopics,
 			existingTopics,
@@ -29,8 +31,11 @@ export default {
 			updatedReactions,
 			deleteReactionIds,
 		} = await getNewData(env)
+		console.log(`Fetched all relevant data in ${performance.now() - start}ms`)
 
+		const saveStart = performance.now()
 		await saveData({
+			allMessageIds,
 			channels: newChannels,
 			topics: newTopics,
 			existingTopics,
@@ -43,6 +48,7 @@ export default {
 			deleteReactionIds,
 			env,
 		})
+		console.log(`Saved all relevant data in ${performance.now() - saveStart}ms`)
 
 		// To be deleted after attachments width and height are updated
 		await updateAttachments({ messagesWithAttachments, env })


### PR DESCRIPTION

- Ensure we fetch all archived threads (mostly useful for first import on empty db I suppose)
- Handle duplicate slugs on topic inserts
- Bulk insert messages, and make sure they're inserted in the correct order when they reference other messages
- Exclude message references to unknown messages
- Handle errors when trying to parse URL in markdown parser
  